### PR TITLE
Update TPIP schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,8 @@ on:
     tags:
       - "*"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  tpip-check:
-    uses: Open-CMSIS-Pack/generator-bridge/.github/workflows/tpip-check.yml@main
-
   goreleaser:
-    needs: [ tpip-check ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/tpip-check.yml
+++ b/.github/workflows/tpip-check.yml
@@ -7,10 +7,9 @@ on:
       - "**/go.mod"
       - "**/go.sum"
       - "configs/**"
-  workflow_call:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,7 +40,6 @@ jobs:
       - name: Generate TPIP Report
         run:  |
           go-licenses report . --ignore github.com/Open-CMSIS-Pack/generator-bridge --template ../configs/${{ env.report_name }}.template > ../${{ env.report_name }}
-          date +"%Y/%m/%d %T" >> ../${{ env.report_name }}
         working-directory: ./cmd
         
       - name: Archive tpip report
@@ -61,10 +59,7 @@ jobs:
     # Running this job only on specific event
     # in order to have workaround for issue
     # related to deletion of GH checks/status data
-    if: |
-      (github.event_name == 'schedule') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'workflow_call')
+    if: (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch')
     needs: [ check-licenses ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -83,10 +78,10 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: Update TPIP report
-          title: '[TPIP] Update report'
+          title: ':robot: [TPIP] Automated report updates'
           body: |
-            - Third-party IP report updates
+            Third party IP report updates
           branch: update-tpip
           delete-branch: true
           labels: TPIP
-      
+          reviewers: soumeh01

--- a/configs/third_party_licenses.md.template
+++ b/configs/third_party_licenses.md.template
@@ -6,4 +6,4 @@
 | {{ .Name }} | {{ .Version }}  | [{{ .LicenseName }}]({{ .LicenseURL }}) |
 {{- end }}
 
-Report generated and repository checked for [forbidden](https://github.com/google/licenseclassifier/blob/842c0d70d7027215932deb13801890992c9ba364/license_type.go#L323) and [restricted](https://github.com/google/licenseclassifier/blob/842c0d70d7027215932deb13801890992c9ba364/license_type.go#L176) licenses on: 
+Report generated and repository checked for [forbidden](https://github.com/google/licenseclassifier/blob/842c0d70d7027215932deb13801890992c9ba364/license_type.go#L323) and [restricted](https://github.com/google/licenseclassifier/blob/842c0d70d7027215932deb13801890992c9ba364/license_type.go#L176) licenses.


### PR DESCRIPTION
Run TPIP workflow nightly. It will create a PR only when it finds a change in the packages used.
Also for simplicity of the solution, we have removed the timestamp from the report.