### PR TITLE
Fix STM32CubeMX launch failure for a board with specified revision.

### DIFF
--- a/internal/cbuild/cbuild.go
+++ b/internal/cbuild/cbuild.go
@@ -201,11 +201,18 @@ func ReadCbuildgenIdx(name, outPath string, params *ParamsType) error {
 		params.Device = cbuildGenIdxDevice
 		params.OutPath = cbuildGenIdxOutputPath
 
+		var board string
 		split := strings.SplitAfter(cbuildGenIdx.Board, "::")
 		if len(split) == 2 {
-			params.Board = split[1]
+			board = split[1]
 		} else {
-			params.Board = cbuildGenIdx.Board
+			board = cbuildGenIdx.Board
+		}
+		split = strings.Split(board, ":")
+		if len(split) == 2 {
+			params.Board = split[0]
+		} else {
+			params.Board = board
 		}
 
 		var secureContextName string


### PR DESCRIPTION
This commit fixes an issue where STM32CubeMX would fail to launch when the board name included a revision number. The revision has been removed from the board name, and STM32CubeMX now launches correctly.