### PR TITLE
Nxp/support run generator script mac linux

### DIFF
--- a/scripts/MCUXpresso_Config_Tools/darwin-amd64/launch-MCUXpressoConfigTools
+++ b/scripts/MCUXpresso_Config_Tools/darwin-amd64/launch-MCUXpressoConfigTools
@@ -1,15 +1,13 @@
 #!/bin/bash
-# Script launch MCUXpresso Config Tools in OpenCMSIS generator mode. It is supported since MCUXpresso Config Tools v16
+# Launch MCUXpresso Config Tools in OpenCMSIS generator mode. It supports MCUXpresso Config Tools v16 and newer.
 
-# path to .cbuild-gen.idx.yml file
+# Path to .cbuild-gen.idx.yml file
 idxFile=$1
 
-#  Get Config Tools Location
+# Get Config Tools Location
 package_id="com.nxp.*MCUXpresso*Config*"
-
 latest_version="0"
 latest_app_path=""
-
 # Find all applications with the given package identifier
 while IFS= read -r line; do
     apps+=("$line")
@@ -26,9 +24,9 @@ for app_path in "${apps[@]}"; do
   fi
 done
 
-# Exit script config tools was not found
+# Exit script if config tools are not found
 if [[ -z "$latest_app_path" ]]; then
-  echo "MCUXpresso config tools was not found!"
+  echo "MCUXpresso config tools were not found!"
   exit 1
 fi
 tools_path=$latest_app_path

--- a/scripts/MCUXpresso_Config_Tools/darwin-amd64/launch-MCUXpressoConfigTools
+++ b/scripts/MCUXpresso_Config_Tools/darwin-amd64/launch-MCUXpressoConfigTools
@@ -1,5 +1,37 @@
-#!/bin/sh
-# Script launch MCUXpresso Config Tools in OpenCMSIS generator mode.
+#!/bin/bash
+# Script launch MCUXpresso Config Tools in OpenCMSIS generator mode. It is supported since MCUXpresso Config Tools v16
 
-echo Platform is not supported for MCUXpresso Config Tools in OpenCMSIS generator mode!
-exit 1
+# path to .cbuild-gen.idx.yml file
+idxFile=$1
+
+#  Get Config Tools Location
+package_id="com.nxp.*MCUXpresso*Config*"
+
+latest_version="0"
+latest_app_path=""
+
+# Find all applications with the given package identifier
+while IFS= read -r line; do
+    apps+=("$line")
+done < <(mdfind "kMDItemKind == 'Application' && kMDItemCFBundleIdentifier == '$package_id'")
+# Find the latest version
+for app_path in "${apps[@]}"; do
+  version=$(defaults read "$app_path/Contents/Info.plist" CFBundleShortVersionString)
+  if [ -z "$version" ]; then
+    continue
+  fi
+  if [ $(echo "$version > $latest_version" | bc) -eq 1 ]; then
+    latest_version="$version"
+    latest_app_path="$app_path"
+  fi
+done
+
+# Exit script config tools was not found
+if [[ -z "$latest_app_path" ]]; then
+  echo "MCUXpresso config tools was not found!"
+  exit 1
+fi
+tools_path=$latest_app_path
+
+# Launch config tools
+open -W -n "$tools_path" --args -CreateFromProject $idxFile -OpencmsisGeneratorCgen

--- a/scripts/MCUXpresso_Config_Tools/darwin-arm64/launch-MCUXpressoConfigTools
+++ b/scripts/MCUXpresso_Config_Tools/darwin-arm64/launch-MCUXpressoConfigTools
@@ -1,15 +1,13 @@
 #!/bin/bash
-# Script launch MCUXpresso Config Tools in OpenCMSIS generator mode. It is supported since MCUXpresso Config Tools v16
+# Launch MCUXpresso Config Tools in OpenCMSIS generator mode. It supports MCUXpresso Config Tools v16 and newer.
 
-# path to .cbuild-gen.idx.yml file
+# Path to .cbuild-gen.idx.yml file
 idxFile=$1
 
-#  Get Config Tools Location
+# Get Config Tools Location
 package_id="com.nxp.*MCUXpresso*Config*"
-
 latest_version="0"
 latest_app_path=""
-
 # Find all applications with the given package identifier
 while IFS= read -r line; do
     apps+=("$line")
@@ -26,9 +24,9 @@ for app_path in "${apps[@]}"; do
   fi
 done
 
-# Exit script config tools was not found
+# Exit script if config tools are not found
 if [[ -z "$latest_app_path" ]]; then
-  echo "MCUXpresso config tools was not found!"
+  echo "MCUXpresso config tools were not found!"
   exit 1
 fi
 tools_path=$latest_app_path

--- a/scripts/MCUXpresso_Config_Tools/darwin-arm64/launch-MCUXpressoConfigTools
+++ b/scripts/MCUXpresso_Config_Tools/darwin-arm64/launch-MCUXpressoConfigTools
@@ -1,5 +1,37 @@
-#!/bin/sh
-# Script launch MCUXpresso Config Tools in OpenCMSIS generator mode.
+#!/bin/bash
+# Script launch MCUXpresso Config Tools in OpenCMSIS generator mode. It is supported since MCUXpresso Config Tools v16
 
-echo Platform is not supported for MCUXpresso Config Tools in OpenCMSIS generator mode!
-exit 1
+# path to .cbuild-gen.idx.yml file
+idxFile=$1
+
+#  Get Config Tools Location
+package_id="com.nxp.*MCUXpresso*Config*"
+
+latest_version="0"
+latest_app_path=""
+
+# Find all applications with the given package identifier
+while IFS= read -r line; do
+    apps+=("$line")
+done < <(mdfind "kMDItemKind == 'Application' && kMDItemCFBundleIdentifier == '$package_id'")
+# Find the latest version
+for app_path in "${apps[@]}"; do
+  version=$(defaults read "$app_path/Contents/Info.plist" CFBundleShortVersionString)
+  if [ -z "$version" ]; then
+    continue
+  fi
+  if [ $(echo "$version > $latest_version" | bc) -eq 1 ]; then
+    latest_version="$version"
+    latest_app_path="$app_path"
+  fi
+done
+
+# Exit script config tools was not found
+if [[ -z "$latest_app_path" ]]; then
+  echo "MCUXpresso config tools was not found!"
+  exit 1
+fi
+tools_path=$latest_app_path
+
+# Launch config tools
+open -W -n "$tools_path" --args -CreateFromProject $idxFile -OpencmsisGeneratorCgen

--- a/scripts/MCUXpresso_Config_Tools/linux-amd64/launch-MCUXpressoConfigTools
+++ b/scripts/MCUXpresso_Config_Tools/linux-amd64/launch-MCUXpressoConfigTools
@@ -1,20 +1,16 @@
 #!/bin/bash
-# Script launch MCUXpresso Config Tools in OpenCMSIS generator mode on Ubuntu. It is supported since MCUXpresso Config Tools v16
+# Launch MCUXpresso Config Tools in OpenCMSIS generator mode on Ubuntu. It supports MCUXpresso Config Tools v16 and newer.
 
-# path to .cbuild-gen.idx.yml file
+# Path to .cbuild-gen.idx.yml file
 idxFile=$1
 
-# Find all applications with the given package identifier
+# Get Config Tools Location
 package_id="mcuxpresso-config"
-apps=$(ls /usr/share/applications | grep -i "$package_id")
-#if [ ${#apps[@]} -eq 0 ]; then
-if  [ -z "@apps" ]; then
-  echo "No apps found"
-  exit 1
-fi
-# Find the latest
 latest_app=""
 latest_version="0"
+# Find all applications with the given package identifier
+apps=$(ls /usr/share/applications | grep -i "$package_id")
+# Find the latest
 for app in $apps; do
   version=$(grep -i "Version" /usr/share/applications/$app | cut -d '=' -f 2)
   if [ -z "$version" ]; then
@@ -25,6 +21,12 @@ for app in $apps; do
     latest_app="$app"
   fi
 done
+
+# Exit script if config tools are not found
+if  [[ -z "$latest_app" ]]; then
+  echo "MCUXpresso config tools were not found!"
+  exit 1
+fi
 tools_path=$(grep -i "Exec" /usr/share/applications/$latest_app | cut -d '=' -f 2-)
 tools_folder=$(grep -i "Path" /usr/share/applications/$latest_app | cut -d '=' -f 2-)
 

--- a/scripts/MCUXpresso_Config_Tools/linux-amd64/launch-MCUXpressoConfigTools
+++ b/scripts/MCUXpresso_Config_Tools/linux-amd64/launch-MCUXpressoConfigTools
@@ -1,5 +1,34 @@
-#!/bin/sh
-# Script launch MCUXpresso Config Tools in OpenCMSIS generator mode.
+#!/bin/bash
+# Script launch MCUXpresso Config Tools in OpenCMSIS generator mode on Ubuntu. It is supported since MCUXpresso Config Tools v16
 
-echo Platform is not supported for MCUXpresso Config Tools in OpenCMSIS generator mode!
-exit 1
+# path to .cbuild-gen.idx.yml file
+idxFile=$1
+
+# Find all applications with the given package identifier
+package_id="mcuxpresso-config"
+apps=$(ls /usr/share/applications | grep -i "$package_id")
+#if [ ${#apps[@]} -eq 0 ]; then
+if  [ -z "@apps" ]; then
+  echo "No apps found"
+  exit 1
+fi
+# Find the latest
+latest_app=""
+latest_version="0"
+for app in $apps; do
+  version=$(grep -i "Version" /usr/share/applications/$app | cut -d '=' -f 2)
+  if [ -z "$version" ]; then
+    continue
+  fi
+  if [ $(echo "$version > $latest_version" | bc) -eq 1 ]; then
+    latest_version="$version"
+    latest_app="$app"
+  fi
+done
+tools_path=$(grep -i "Exec" /usr/share/applications/$latest_app | cut -d '=' -f 2-)
+tools_folder=$(grep -i "Path" /usr/share/applications/$latest_app | cut -d '=' -f 2-)
+
+# Launch config tools from its folder, hide console output
+pushd $tools_folder
+$tools_path -CreateFromProject $idxFile -OpencmsisGeneratorCgen &> /dev/null
+popd

--- a/scripts/MCUXpresso_Config_Tools/windows-amd64/launch-MCUXpressoConfigTools.bat
+++ b/scripts/MCUXpresso_Config_Tools/windows-amd64/launch-MCUXpressoConfigTools.bat
@@ -1,18 +1,18 @@
 @echo off
-REM Script launch MCUXpresso Config Tools in OpenCMSIS generator mode. It is supported since MCUXpresso Config Tools v16
+REM Launch MCUXpresso Config Tools in OpenCMSIS generator mode. It supports MCUXpresso Config Tools v16 and newer.
 
-REM path to .cbuild-gen.idx.yml file
+REM Path to .cbuild-gen.idx.yml file
 set idxFile=%1
 
-REM  Get Config Tools Location
+REM Get Config Tools Location
 set cmd=REG QUERY "HKEY_CLASSES_ROOT\NXP Semiconductors.MCUXpresso Config Tools.mex\shell\open\command" /ve
 FOR /F usebackq^ tokens^=2^ delims^=^"  %%F IN (`%cmd%`) DO (
   SET tools_path=%%F
 )
 
-REM Exit script config tools was not found
+REM Exit script if config tools are not found
 if not defined tools_path (
-    echo MCUXpresso config tools was not found!
+    echo MCUXpresso config tools were not found!
     exit /b 1
 )
 


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->

- Supported scripts to launch MCUXpresso config tools as generator for MacOS(amd,arm), Linux(amd)
- Improved grammar in script  to launch MCUXpresso config tools as generator for Windows

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [ ] 🤖 This change is covered by unit tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 🛡️ Security impacts have been considered.
- [ ] 📖 All documentation updates are complete.
- [ ] 🧠 This change does not change third-party dependencies
