### PR TITLE
Removed deprecated action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,11 @@ jobs:
       GO111MODULE: on
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+
       - name: Checkout Source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -186,7 +191,7 @@ jobs:
           path: artifacts
 
       - name: publish test results
-        uses: EnricoMi/publish-unit-test-result-action/composite@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
+        uses: EnricoMi/publish-unit-test-result-action/linux@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           junit_files: "artifacts/**/${{ env.program }}-testreport-*.xml"


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- Fixed warning by removing the deprecated composite action and used the relevant one as stated here
https://github.com/EnricoMi/publish-unit-test-result-action/tree/v2?tab=readme-ov-file#running-as-a-composite-action

## Changes
<!-- List the changes this PR introduces -->
-

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
