### PR TITLE
Place scripts in root directory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ archives:
       - README.md
       - third_party_licenses.md
       - src: scripts/MCUXpresso_Config_Tools/{{.Os}}-{{.Arch}}/launch-MCUXpressoConfigTools*
+        strip_parent: true
       - src: scripts/Infineon_Device_Configurator/{{.Os}}-{{.Arch}}/launch-Infineon_Dev_Config*
         strip_parent: true
 


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
- `strip_parent` property is only applied to one src. Hence placing `launch-MCUXpressoConfigTools` script under `<root>/scripts/MCUXpresso_Config_Tools/{{.Os}}-{{.Arch}}/` of release folder. It should be placed right next to cbridge binary in root folder.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
