### PR TITLE
strip optional Pname from load

### DIFF
--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -389,7 +389,7 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 	var text utils.TextBuilder
 	if params.BoardName != "" && params.BoardVendor == "STMicroelectronics" {
 		text.AddLine("loadboard", params.BoardName, "allmodes")
-	} else
+	} else {
 		// extract Dname from [vendor]::Dname:[Pname]
 		parts := strings.SplitN(params.Device, "::",2)
 		
@@ -402,7 +402,7 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 		
 		parts := strings.SplitN(DnamePname, ":", 2)
 		if len(parts) >= 1 {
-			text.AddLine("load", parts[0]
+			text.AddLine("load", parts[0])
 		} else {
 			text.AddLine("load", DnamePname)
 		}

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -389,12 +389,22 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 	var text utils.TextBuilder
 	if params.BoardName != "" && params.BoardVendor == "STMicroelectronics" {
 		text.AddLine("loadboard", params.BoardName, "allmodes")
-	} else {
-		split := strings.Split(params.Device, "::")
-		if len(split) >= 1 {
-			text.AddLine("load", split[len(split)-1])
+	} else
+		// extract Dname from [vendor]::Dname:[Pname]
+		parts := strings.SplitN(params.Device, "::",2)
+		
+		var DnamePname string
+		if len(parts) == 2 {
+			DnamePname = parts[1]
 		} else {
-			text.AddLine("load", params.Device)
+			DnamePname = params.Device
+		}
+		
+		parts := strings.SplitN(DnamePname, ":", 2)
+		if len(parts) >= 1 {
+			text.AddLine("load", parts[0]
+		} else {
+			text.AddLine("load", DnamePname)
 		}
 	}
 	text.AddLine("project name", "STM32CubeMX")

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -392,14 +392,12 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 	} else {
 		// extract Dname from [vendor]::Dname:[Pname]
 		parts := strings.SplitN(params.Device, "::", 2)
-		
 		var DnamePname string
 		if len(parts) == 2 {
 			DnamePname = parts[1]
 		} else {
 			DnamePname = params.Device
-		}
-		
+		}		
 		parts = strings.SplitN(DnamePname, ":", 2)
 		if len(parts) >= 1 {
 			text.AddLine("load", parts[0])

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -398,6 +398,7 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 		} else {
 			DnamePname = params.Device
 		}		
+		
 		parts = strings.SplitN(DnamePname, ":", 2)
 		if len(parts) >= 1 {
 			text.AddLine("load", parts[0])

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -400,11 +400,7 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 		}		
 		
 		parts = strings.SplitN(DnamePname, ":", 2)
-		if len(parts) >= 1 {
-			text.AddLine("load", parts[0])
-		} else {
-			text.AddLine("load", DnamePname)
-		}
+		text.AddLine("load", parts[0])
 	}
 	text.AddLine("project name", "STM32CubeMX")
 

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -398,7 +398,7 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 		} else {
 			DnamePname = params.Device
 		}
-	
+
 		parts = strings.SplitN(DnamePname, ":", 2)
 		text.AddLine("load", parts[0])
 	}

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -391,7 +391,7 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 		text.AddLine("loadboard", params.BoardName, "allmodes")
 	} else {
 		// extract Dname from [vendor]::Dname:[Pname]
-		parts := strings.SplitN(params.Device, "::",2)
+		parts := strings.SplitN(params.Device, "::", 2)
 		
 		var DnamePname string
 		if len(parts) == 2 {

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -400,7 +400,7 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 			DnamePname = params.Device
 		}
 		
-		parts := strings.SplitN(DnamePname, ":", 2)
+		parts = strings.SplitN(DnamePname, ":", 2)
 		if len(parts) >= 1 {
 			text.AddLine("load", parts[0])
 		} else {

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -397,7 +397,7 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 			DnamePname = parts[1]
 		} else {
 			DnamePname = params.Device
-		}		
+		}
 		
 		parts = strings.SplitN(DnamePname, ":", 2)
 		text.AddLine("load", parts[0])

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -398,7 +398,7 @@ func WriteProjectFile(workDir string, params BridgeParamType) (string, error) {
 		} else {
 			DnamePname = params.Device
 		}
-		
+	
 		parts = strings.SplitN(DnamePname, ":", 2)
 		text.AddLine("load", parts[0])
 	}


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- #226 

## Changes
strips optional Pname in case of multi-core device being selected.
-

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
