### PR TITLE
issue #455 fixed by checking for the presence of generated file

### DIFF
--- a/internal/readFile/readFile.go
+++ b/internal/readFile/readFile.go
@@ -21,6 +21,7 @@ func Process(inFile, inFile2, outPath string) error {
 	log.Debugf("Reading file: %v", inFile)
 	if outPath == "" {
 		outPath = filepath.Dir(inFile2)
+		outPath = filepath.Join(outPath, "..")
 	}
 
 	var cbuildParams cbuild.ParamsType
@@ -91,8 +92,8 @@ func Process(inFile, inFile2, outPath string) error {
 			return err
 		}
 
-		//		err = stm32cubemx.ReadContexts(workDir+"/STM32CubeMX/STM32CubeMX.ioc", params)
-		err = stm32cubemx.ReadContexts(filepath.Join(workDir, "STM32CubeMX.ioc"), params)
+		err = stm32cubemx.ReadContexts(filepath.Join(workDir, "STM32CubeMX", "STM32CubeMX.ioc"), params)
+		// err = stm32cubemx.ReadContexts(filepath.Join(workDir, "STM32CubeMX.ioc"), params)
 		if err != nil {
 			return err
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -73,7 +73,7 @@ func ConvertFilename(outPath, file, relativePathAdd string) (string, error) {
 	alreadyFound := false
 	if !filepath.IsAbs(file) {
 		toolchainPath := filepath.Join(outPath, relativePathAdd) // create the path where STCube sets it's files relative to toolchain folder( example :./STM32CubeMX/MDK-ARM/)
-		file1 := filepath.Join(toolchainPath, relativePathAdd, file)
+		file1 := filepath.Join(toolchainPath, "dummyPath", file) // add dummyPath to allow to check also in subfolders
 		if _, err := os.Stat(file1); errors.Is(err, os.ErrNotExist) {
 			file = filepath.Join(toolchainPath, file)
 		} else {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -69,14 +69,23 @@ func ConvertFilename(outPath, file, relativePathAdd string) (string, error) {
 	file = filepath.Clean(file)
 	file = filepath.ToSlash(file)
 
-	// Check if the file is absolute
+	// Check if the file is relative
+	alreadyFound := false
 	if !filepath.IsAbs(file) {
 		toolchainPath := filepath.Join(outPath, relativePathAdd) // create the path where STCube sets it's files relative to toolchain folder( example :./STM32CubeMX/MDK-ARM/)
-		file = filepath.Join(toolchainPath, file)
+		file1 := filepath.Join(toolchainPath, relativePathAdd, file)
+		if _, err := os.Stat(file1); errors.Is(err, os.ErrNotExist) {
+			file = filepath.Join(toolchainPath, file)
+		} else {
+			file = file1
+			alreadyFound = true
+		}
 	}
 
-	if _, err := os.Stat(file); errors.Is(err, os.ErrNotExist) {
-		log.Errorf("file or directory not found: %v", file)
+	if !alreadyFound {
+		if _, err := os.Stat(file); errors.Is(err, os.ErrNotExist) {
+			log.Errorf("file or directory not found: %v", file)
+		}
 	}
 
 	var err error

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -148,6 +148,7 @@ func TestConvertFilename(t *testing.T) {
 		{"testAbs", args{"../../testdata", "C:/test.ioc", "stm32cubemx"}, true, "C:/test.ioc", false},
 		{"test", args{"../../testdata", "test.ioc", "stm32cubemx"}, false, "./stm32cubemx/test.ioc", false},
 		{"nix", args{"../../testdata", "nix", "stm32cubemx"}, false, "./stm32cubemx/nix", false},
+		{"testRelBack", args{"../../testdata", "../test.ioc", "stm32cubemx"}, false, "./stm32cubemx/test.ioc", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
... also one level deeper and if found, correct the path

## Fixes
- Issue [#455](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/455) : [Bug] cbridge: generated *.cgen.yml contains file references with incorrect path for selected middleware

## Changes
- check for existing files also one level deeper and then use that path

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
