### PR TITLE
🤖 Update go-workflows to v1.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build-and-verify:
-    uses: Open-CMSIS-Pack/workflows-and-actions-collection/.github/workflows/build-and-verify.yml@v1.0.2
+    uses: Open-CMSIS-Pack/workflows-and-actions-collection/.github/workflows/build-and-verify.yml@v1.0.3
     secrets:
       QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       program: cbridge
       go-version-file: ./go.mod
-      enable-qlty-coverage: true
+      enable-qlty-coverage: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 
   publish-test-results:
     name: "Publish Tests Results"

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -17,7 +17,7 @@ permissions: read-all
 
 jobs:
   markdown-check:
-    uses: Open-CMSIS-Pack/workflows-and-actions-collection/.github/workflows/markdown-lint.yml@v1.0.2
+    uses: Open-CMSIS-Pack/workflows-and-actions-collection/.github/workflows/markdown-lint.yml@v1.0.3
     with:
       lint-config: '.github/markdownlint.jsonc'
       link-check-config: '.github/markdown-link-check.jsonc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
       actions: write
-    uses: Open-CMSIS-Pack/workflows-and-actions-collection/.github/workflows/build-and-verify.yml@v1.0.2
+    uses: Open-CMSIS-Pack/workflows-and-actions-collection/.github/workflows/build-and-verify.yml@v1.0.3
     with:
       program: cbridge
       go-version-file: ./go.mod

--- a/.github/workflows/update-workflows.yml
+++ b/.github/workflows/update-workflows.yml
@@ -11,6 +11,6 @@ permissions:
 jobs:
   update-workflows:
     name: Update Workflow References
-    uses: Open-CMSIS-Pack/workflows-and-actions-collection/.github/workflows/update-workflow.yml@v1.0.2
+    uses: Open-CMSIS-Pack/workflows-and-actions-collection/.github/workflows/update-workflow.yml@v1.0.3
     secrets:
       TOKEN_ACCESS: ${{ secrets.GRASCI_WORKFLOW_UPDATE }}


### PR DESCRIPTION
## Changes
-  Updates all common workflows references to the latest version.
-  Selective run coverage
     - `true `for pushes and non-PR events
     - `true `for PRs from branches in the same repo
     - `false `for PRs from forks