### PR TITLE
Pin trivy plugin version to 0.69.3

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -69,6 +69,7 @@ name = "ripgrep"          # Fast searching for pattern matching in codebase
 
 [[plugin]]
 name = "trivy"            # Scans for vulnerabilities in containers and dependencies
+version = "0.69.3"        # Pinned to secure version
 
 [[plugin]]
 name = "trufflehog"       # Detects secrets and sensitive data in code


### PR DESCRIPTION
## Changes
- Pinned to [safer version](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23) i.e. 0.69.3

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
