### PR TITLE
Improve CubeMX event handling, cgen logging and non-blocking MX_Device generation behavior

### DIFF
--- a/internal/stm32CubeMX/mxDevice.go
+++ b/internal/stm32CubeMX/mxDevice.go
@@ -9,6 +9,7 @@ package stm32cubemx
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io/fs"
 	"math"
 	"os"
@@ -18,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type PinDefinition struct {
@@ -71,7 +74,7 @@ func ReadContexts(iocFile string, params []BridgeParamType) error {
 				if parm.CubeContextFolder != "" {
 					cfgPath = filepath.Join(cfgPath, parm.CubeContextFolder)
 				}
-				err := writeMXdeviceH(contextMap, srcFolderPath, mspName, cfgPath, context)
+				err := writeMXdeviceH(contextMap, srcFolderPath, mspName, cfgPath, context, parm.CgenName)
 				if err != nil {
 					return err
 				}
@@ -110,7 +113,7 @@ func createContextMap(iocFile string) (map[string]map[string]string, error) {
 	return contextMap, nil
 }
 
-func writeMXdeviceH(contextMap map[string]map[string]string, srcFolder string, mspName string, cfgPath string, context string) error {
+func writeMXdeviceH(contextMap map[string]map[string]string, srcFolder string, mspName string, cfgPath string, context string, cgenPath string) error {
 
 	srcFolderAbs, err := filepath.Abs(srcFolder)
 	if err != nil {
@@ -213,8 +216,12 @@ func writeMXdeviceH(contextMap map[string]map[string]string, srcFolder string, m
 					periPath = filepath.ToSlash(periPath)
 					fPeri, errPeri := os.Open(periPath)
 					if errPeri != nil {
-						return errPeri
+						warnErr := fmt.Errorf("warning: failed to open peripheral source '%s' for '%s': %w", periPath, peripheral, errPeri)
+						logCgenError(cgenPath, warnErr)
+						log.Warnf("%v", warnErr)
+						break
 					} else {
+						defer fPeri.Close()
 						pins, err = getPins(contextMap, fPeri, peripheral)
 						if err != nil {
 							return err
@@ -246,7 +253,6 @@ func writeMXdeviceH(contextMap map[string]map[string]string, srcFolder string, m
 							freq = getSPIFreq(fPeri, contextMap, peripheral)
 						}
 					}
-					defer fPeri.Close()
 					break
 				}
 			}

--- a/internal/stm32CubeMX/mxDevice.go
+++ b/internal/stm32CubeMX/mxDevice.go
@@ -214,44 +214,52 @@ func writeMXdeviceH(contextMap map[string]map[string]string, srcFolder string, m
 					}
 					periPath := filepath.Join(srcFolderAbs, fileName)
 					periPath = filepath.ToSlash(periPath)
-					fPeri, errPeri := os.Open(periPath)
-					if errPeri != nil {
-						warnErr := fmt.Errorf("warning: failed to open peripheral source '%s' for '%s': %w", periPath, peripheral, errPeri)
-						logCgenError(cgenPath, warnErr)
-						log.Warnf("%v", warnErr)
-						break
-					} else {
+					err = func() error {
+						fPeri, errPeri := os.Open(periPath)
+						if errPeri != nil {
+							warnErr := fmt.Errorf("warning: failed to open peripheral source '%s' for '%s': %w", periPath, peripheral, errPeri)
+							logCgenError(cgenPath, warnErr)
+							log.Warnf("%v", warnErr)
+							return nil
+						}
 						defer fPeri.Close()
+
 						pins, err = getPins(contextMap, fPeri, peripheral)
 						if err != nil {
 							return err
 						}
-					}
-					/* peripherals custom infos */
-					if strings.Contains(peripheral, "I2C") {
-						i2cInfo, err = getI2cInfo(fPeri, peripheral)
-						if err != nil {
-							return err
+
+						/* peripherals custom infos */
+						if strings.Contains(peripheral, "I2C") {
+							i2cInfo, err = getI2cInfo(fPeri, peripheral)
+							if err != nil {
+								return err
+							}
+						} else if strings.Contains(peripheral, "USB") {
+							usbHandle, err = getUSBHandle(fPeri, peripheral)
+							if err != nil {
+								return err
+							}
+						} else if strings.Contains(peripheral, "SDMMC") {
+							mciMode, err = getMCIMode(fPeri, peripheral)
+							if err != nil {
+								return err
+							}
+						} else if strings.Contains(peripheral, "SDIO") {
+							mciMode, err = getMCIMode(fPeri, peripheral)
+							if err != nil {
+								return err
+							}
+						} else if strings.Contains(peripheral, "SPI") {
+							if freq == "" {
+								freq = getSPIFreq(fPeri, contextMap, peripheral)
+							}
 						}
-					} else if strings.Contains(peripheral, "USB") {
-						usbHandle, err = getUSBHandle(fPeri, peripheral)
-						if err != nil {
-							return err
-						}
-					} else if strings.Contains(peripheral, "SDMMC") {
-						mciMode, err = getMCIMode(fPeri, peripheral)
-						if err != nil {
-							return err
-						}
-					} else if strings.Contains(peripheral, "SDIO") {
-						mciMode, err = getMCIMode(fPeri, peripheral)
-						if err != nil {
-							return err
-						}
-					} else if strings.Contains(peripheral, "SPI") {
-						if freq == "" {
-							freq = getSPIFreq(fPeri, contextMap, peripheral)
-						}
+
+						return nil
+					}()
+					if err != nil {
+						return err
 					}
 					break
 				}

--- a/internal/stm32CubeMX/mxDevice_test.go
+++ b/internal/stm32CubeMX/mxDevice_test.go
@@ -163,7 +163,7 @@ func Test_writeMXdeviceH(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer os.RemoveAll(tt.args.srcFolder + "/../" + tt.args.cfgPath)
-			if err := writeMXdeviceH(tt.args.contextMap, tt.args.srcFolder, tt.args.mspName, tt.args.cfgPath, tt.args.context); (err != nil) != tt.wantErr {
+			if err := writeMXdeviceH(tt.args.contextMap, tt.args.srcFolder, tt.args.mspName, tt.args.cfgPath, tt.args.context, "test.cgen.yml"); (err != nil) != tt.wantErr {
 				t.Errorf("writeMXdeviceH() %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			}
 		})

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -75,6 +75,97 @@ func procWait(proc *os.Process) {
 	}
 }
 
+func cgenPathsFromBridgeParams(bridgeParams []BridgeParamType) []string {
+	cgenPaths := make([]string, 0, len(bridgeParams))
+	for _, bp := range bridgeParams {
+		cgenPaths = append(cgenPaths, bp.CgenName)
+	}
+	return cgenPaths
+}
+
+func resetDebounceTimer(timer *time.Timer, interval time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(interval)
+}
+
+func handleCubeMxWatchEvent(event fsnotify.Event, cubeIocPath, iocprojectPath, mxprojectPath string, cgenPaths []string, addWatch func(string) error) bool {
+	if filepath.Clean(event.Name) == filepath.Clean(cubeIocPath) && (event.Op&fsnotify.Create) != 0 {
+		if err := addWatch(cubeIocPath); err != nil {
+			log.Debugf("failed to watch CubeMX dir after creation '%s': %v", cubeIocPath, err)
+		}
+	}
+
+	return isRelevantCubeMxEvent(event, cubeIocPath, iocprojectPath, mxprojectPath, cgenPaths)
+}
+
+func isRelevantCubeMxEvent(event fsnotify.Event, cubeIocPath, iocprojectPath, mxprojectPath string, cgenPaths []string) bool {
+	eventName := filepath.Clean(event.Name)
+	iocprojectPath = filepath.Clean(iocprojectPath)
+	mxprojectPath = filepath.Clean(mxprojectPath)
+	cubeIocPath = filepath.Clean(cubeIocPath)
+
+	// Check for Create/Write/Rename on CubeMX project files
+	if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename) != 0 {
+		if eventName == iocprojectPath || eventName == mxprojectPath || eventName == cubeIocPath {
+			return true
+		}
+
+		if eventName != "." && eventName != "" {
+			if strings.HasPrefix(eventName, cubeIocPath+string(os.PathSeparator)) {
+				return true
+			}
+		}
+	}
+
+	// Check for removal or rename of any cgen.yml file (triggers regeneration)
+	if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+		for _, cgenPath := range cgenPaths {
+			if eventName == filepath.Clean(cgenPath) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func processCubeMxUpdate(workDir, iocprojectPath, mxprojectPath string, bridgeParams []BridgeParamType) error {
+	if !utils.FileExists(iocprojectPath) {
+		return errors.New("project file not available yet")
+	}
+	if !utils.FileExists(mxprojectPath) {
+		return errors.New(".mxproject file not available yet")
+	}
+
+	mxproject, err := IniReader(mxprojectPath, bridgeParams)
+	if err != nil {
+		// Log to all cgen files since this is a blocking error
+		for _, bp := range bridgeParams {
+			logCgenError(bp.CgenName, err)
+		}
+		return err
+	}
+	if err = ReadContexts(iocprojectPath, bridgeParams); err != nil {
+		// Log to all cgen files since this is a blocking error
+		for _, bp := range bridgeParams {
+			logCgenError(bp.CgenName, err)
+		}
+		return err
+	}
+
+	log.Debugln("Writing Cgen.yml file")
+	return WriteCgenYml(workDir, mxproject, bridgeParams)
+}
+
+// Process handles setup, launch, and daemon monitoring for CubeMX integration.
+// The live daemon loop in the pid >= 0 branch is intentionally out of scope for
+// unit testing because it depends on live OS processes via procWait, live
+// filesystem watchers, and goroutine synchronization with real-time delays.
 func Process(cbuildGenIdxYmlPath, outPath, cubeMxPath string, runCubeMx bool, pid int) error {
 	var projectFile string
 
@@ -163,125 +254,88 @@ func Process(cbuildGenIdxYmlPath, outPath, cubeMxPath string, runCubeMx bool, pi
 		}
 		iocprojectPath := filepath.Join(cubeIocPath, "STM32CubeMX.ioc")
 		mxprojectPath := filepath.Join(cubeIocPath, ".mxproject")
-		log.Debugf("pid of CubeMX in daemon: %d", pid)
-		running = true
-		first := true
-		iocProjectWait := false
-		for {
-			proc, err := os.FindProcess(pid) // this only works for windows as it is now
-			if err == nil {                  // cubeMX already runs
-				if runtime.GOOS != "windows" {
-					err = proc.Signal(syscall.Signal(0))
-					if err != nil {
-						break // out of loop if CubeMX does not run anymore
-					}
+
+		cgenPaths := cgenPathsFromBridgeParams(bridgeParams)
+
+		proc, err := os.FindProcess(pid) // this only works for windows as it is now
+		if err == nil {                  // cubeMX already runs
+			if runtime.GOOS != "windows" {
+				err = proc.Signal(syscall.Signal(0))
+				if err != nil {
+					return nil // CubeMX does not run anymore
 				}
-				if first { // only start wait thread once
-					go procWait(proc)
-					first = false
-				}
-				if !running {
-					break // out of loop if CubeMX does not run anymore
-				}
-				stIOC, err := os.Stat(iocprojectPath)
-				if err != nil { // .ioc file not (yet) there
-					iocProjectWait = true
-					time.Sleep(time.Second)
-					continue // stay in loop waiting for CubeMX end or change of .mxproject
-				}
-				if iocProjectWait { // .ioc file was created new, there will not be multiple changes
-					log.Debugln("new project file:", iocprojectPath)
-					i := 1
-					for ; i < 100; i++ { // wait for .mxproject coming
-						_, err := os.Stat(mxprojectPath)
-						if err == nil {
-							break // .mxproject appeared
-						}
-						time.Sleep(time.Second)
-					}
-					if i < 100 {
-						mxproject, err := IniReader(mxprojectPath, bridgeParams)
-						if err != nil {
-							continue // stay in loop waiting for CubeMX end or change of .mxproject
-						}
-						err = ReadContexts(iocprojectPath, bridgeParams)
-						if err != nil {
-							continue // stay in loop waiting for CubeMX end or change of .mxproject
-						}
-						err = WriteCgenYml(workDir, mxproject, bridgeParams)
-						if err != nil {
-							continue // stay in loop waiting for CubeMX end or change of .mxproject
-						}
-						iocProjectWait = false // reset wait for iocProject flag
-					}
-				} else {
-					st, err := os.Stat(mxprojectPath)
-					if err != nil {
-						continue // stay in loop waiting for CubeMX end or change of .mxproject
-					}
-					fIoc, err := os.Open(mxprojectPath)
-					if err != nil {
-						continue // stay in loop waiting for CubeMX end or change of .mxproject
-					}
-					mxprojectBuf := make([]byte, st.Size())
-					_, err = fIoc.Read(mxprojectBuf)
-					if err != nil {
-						log.Fatal(err)
-					}
-					fIoc.Close()
-					for { // wait for .mxproject change
-						//nolint:staticcheck // intentional logic for clarity
-						if !running {
-							break // out of loop if CubeMX does not run anymore
-						}
-						time.Sleep(time.Second)
-						stIOC1, err := os.Stat(iocprojectPath)
-						if err != nil { // .ioc file not (yet) there
-							break // continue loop waiting for CubeMX end or change of .mxproject
-						}
-						st1, err := os.Stat(mxprojectPath)
-						if err != nil {
-							break // continue loop waiting for CubeMX end or change of .mxproject
-						}
-						if stIOC.ModTime() != stIOC1.ModTime() && st.ModTime() != st1.ModTime() { // time changed
-							// it seems to me that the compare is superfluous because there are only in rare cases changes but the time always changes
-							if st.Size() == st1.Size() { // no change in length, compare content
-								fIoc, err := os.Open(mxprojectPath)
-								if err != nil {
-									break // continue loop waiting for CubeMX end or change of .mxproject
-								}
-								mxprojectBuf1 := make([]byte, st1.Size())
-								_, err = fIoc.Read(mxprojectBuf1)
-								if err != nil {
-									log.Fatal(err)
-								}
-								fIoc.Close()
-								// if bytes.Equal(mxprojectBuf, mxprojectBuf1) {
-								//	continue // wait for .mxproject change
-								// }
-							}
-							mxproject, err := IniReader(mxprojectPath, bridgeParams)
-							if err != nil {
-								break // continue loop waiting for CubeMX end or change of .mxproject
-							}
-							err = ReadContexts(iocprojectPath, bridgeParams)
-							if err != nil {
-								break // continue loop waiting for CubeMX end or change of .mxproject
-							}
-							log.Debugln("Writing Cgen.yml file")
-							err = WriteCgenYml(workDir, mxproject, bridgeParams)
-							if err != nil {
-								break // continue loop waiting for CubeMX end or change of .mxproject
-							}
-							break // leave inner loop reload all
-						}
-					}
-				}
-			} else {
-				break // CubeMX does not run anymore
 			}
+
+			running = true
+			go procWait(proc)
+
+			watcher, err = fsnotify.NewWatcher()
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if watcher != nil {
+					_ = watcher.Close()
+					watcher = nil
+				}
+			}()
+
+			if utils.DirExists(workDir) {
+				if err = watcher.Add(workDir); err != nil {
+					log.Debugf("failed to watch work dir '%s': %v", workDir, err)
+				}
+			}
+			if utils.DirExists(cubeIocPath) {
+				if err = watcher.Add(cubeIocPath); err != nil {
+					log.Debugf("failed to watch CubeMX dir '%s': %v", cubeIocPath, err)
+				}
+			}
+
+			// Delete old cgen.log files at daemon startup
+			deleteAllCgenLogs(bridgeParams)
+
+			if err = processCubeMxUpdate(workDir, iocprojectPath, mxprojectPath, bridgeParams); err != nil {
+				log.Debugf("initial CubeMX generation attempt skipped: %v", err)
+			}
+
+			const debounceInterval = time.Second
+			debounceTimer := time.NewTimer(debounceInterval)
+			debounceTimer.Stop() // start inactive
+			hasRelevantEvent := false
+
+			for running {
+				select {
+				case event, ok := <-watcher.Events:
+					if !ok {
+						running = false
+						break
+					}
+
+					if !handleCubeMxWatchEvent(event, cubeIocPath, iocprojectPath, mxprojectPath, cgenPaths, watcher.Add) {
+						continue
+					}
+
+					hasRelevantEvent = true
+					resetDebounceTimer(debounceTimer, debounceInterval)
+
+				case <-debounceTimer.C:
+					if hasRelevantEvent {
+						if err = processCubeMxUpdate(workDir, iocprojectPath, mxprojectPath, bridgeParams); err != nil {
+							log.Debugf("CubeMX generation attempt skipped: %v", err)
+						}
+						hasRelevantEvent = false
+					}
+
+				case err, ok := <-watcher.Errors:
+					if !ok {
+						running = false
+						break
+					}
+					log.Debugf("watcher error: %v", err)
+				}
+			}
+			debounceTimer.Stop()
 		}
-		// should only come here if CubeMX does not run anymore
 	}
 
 	if runCubeMx {
@@ -659,6 +713,7 @@ func WriteCgenYmlSub(outPath string, mxproject MxprojectType, bridgeParam Bridge
 
 	relativePathAdd, err := GetRelativePathAdd(outPath, bridgeParam.Compiler)
 	if err != nil {
+		logCgenError(bridgeParam.CgenName, err)
 		return err
 	}
 
@@ -714,10 +769,12 @@ func WriteCgenYmlSub(outPath string, mxproject MxprojectType, bridgeParam Bridge
 	var cgenFile cbuild.CgenFilesType
 	startupFile, err := GetStartupFile(outPath, bridgeParam)
 	if err != nil {
+		logCgenError(bridgeParam.CgenName, err)
 		return err
 	}
 	startupFile, err = utils.ConvertFilenameRel(outPath, startupFile)
 	if err != nil {
+		logCgenError(bridgeParam.CgenName, err)
 		return err
 	}
 	cgenFile.File = startupFile
@@ -725,10 +782,12 @@ func WriteCgenYmlSub(outPath string, mxproject MxprojectType, bridgeParam Bridge
 
 	systemFile, err := GetSystemFile(outPath, bridgeParam)
 	if err != nil {
+		logCgenError(bridgeParam.CgenName, err)
 		return err
 	}
 	systemFile, err = utils.ConvertFilenameRel(outPath, systemFile)
 	if err != nil {
+		logCgenError(bridgeParam.CgenName, err)
 		return err
 	}
 	cgenFile.File = systemFile
@@ -785,7 +844,13 @@ func WriteCgenYmlSub(outPath string, mxproject MxprojectType, bridgeParam Bridge
 		cgen.GeneratorImport.Groups = append(cgen.GeneratorImport.Groups, groupTz)
 	}
 
-	return common.WriteYml(bridgeParam.CgenName, &cgen)
+	err = common.WriteYml(bridgeParam.CgenName, &cgen)
+	if err != nil {
+		logCgenError(bridgeParam.CgenName, err)
+		return err
+	}
+
+	return nil
 }
 
 func GetToolchain(compiler string) (string, error) {

--- a/internal/stm32CubeMX/stm32CubeMX_cgenlog.go
+++ b/internal/stm32CubeMX/stm32CubeMX_cgenlog.go
@@ -44,7 +44,7 @@ func logCgenError(cgenPath string, err error) {
 	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
 	message := fmt.Sprintf("[%s] %s: %v\n", timestamp, funcName, err)
 
-	file, openErr := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	file, openErr := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if openErr != nil {
 		log.Warnf("failed to open cgen log '%s': %v", logPath, openErr)
 		return

--- a/internal/stm32CubeMX/stm32CubeMX_cgenlog.go
+++ b/internal/stm32CubeMX/stm32CubeMX_cgenlog.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023-2026 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package stm32cubemx
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/open-cmsis-pack/generator-bridge/internal/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+// deleteCgenLog deletes the *.cgen.log file for a given cgen path.
+func deleteCgenLog(cgenPath string) error {
+	logPath := strings.TrimSuffix(cgenPath, ".yml") + ".log"
+	if utils.FileExists(logPath) {
+		return os.Remove(logPath)
+	}
+	return nil
+}
+
+// logCgenError appends an error message with timestamp and function name to the *.cgen.log file.
+func logCgenError(cgenPath string, err error) {
+	logPath := strings.TrimSuffix(cgenPath, ".yml") + ".log"
+
+	// Get caller's function name.
+	pc, _, _, _ := runtime.Caller(1)
+	funcName := "unknown"
+	if fn := runtime.FuncForPC(pc); fn != nil {
+		name := fn.Name()
+		if idx := strings.LastIndex(name, "/"); idx >= 0 && idx+1 < len(name) {
+			name = name[idx+1:]
+		}
+		funcName = name
+	}
+
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	message := fmt.Sprintf("[%s] %s: %v\n", timestamp, funcName, err)
+
+	file, openErr := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if openErr != nil {
+		log.Warnf("failed to open cgen log '%s': %v", logPath, openErr)
+		return
+	}
+	defer file.Close()
+
+	_, writeErr := file.WriteString(message)
+	if writeErr != nil {
+		log.Warnf("failed to write cgen log '%s': %v", logPath, writeErr)
+	}
+}
+
+// deleteAllCgenLogs deletes all *.cgen.log files for the given bridge parameters.
+func deleteAllCgenLogs(bridgeParams []BridgeParamType) {
+	for _, bp := range bridgeParams {
+		_ = deleteCgenLog(bp.CgenName)
+	}
+}

--- a/internal/stm32CubeMX/stm32CubeMX_cgenlog_test.go
+++ b/internal/stm32CubeMX/stm32CubeMX_cgenlog_test.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2023-2026 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package stm32cubemx
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-cmsis-pack/generator-bridge/internal/utils"
+)
+
+func Test_logCgenError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cgenPath := filepath.Join(tmpDir, "test.cgen.yml")
+	logPath := strings.TrimSuffix(cgenPath, ".yml") + ".log"
+
+	// Test writing an error
+	logCgenError(cgenPath, errors.New("test error 1"))
+
+	// Verify the log file exists
+	if !utils.FileExists(logPath) {
+		t.Errorf("expected log file to be created at %s", logPath)
+	}
+
+	// Verify the error message was written with timestamp
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "test error 1") {
+		t.Errorf("expected error message in log file, got: %s", content)
+	}
+	if !strings.Contains(content, "Test_logCgenError") {
+		t.Errorf("expected function name in log file, got: %s", content)
+	}
+
+	// Test appending a second error
+	logCgenError(cgenPath, errors.New("test error 2"))
+
+	data, err = os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file after append: %v", err)
+	}
+
+	content = string(data)
+	if !strings.Contains(content, "test error 1") || !strings.Contains(content, "test error 2") {
+		t.Errorf("expected both error messages in log file, got: %s", content)
+	}
+	if !strings.Contains(content, "Test_logCgenError") {
+		t.Errorf("expected function name in log file, got: %s", content)
+	}
+}
+
+func Test_deleteCgenLog(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cgenPath := filepath.Join(tmpDir, "test.cgen.yml")
+	logPath := strings.TrimSuffix(cgenPath, ".yml") + ".log"
+
+	// Create a log file
+	logCgenError(cgenPath, errors.New("test error"))
+
+	if !utils.FileExists(logPath) {
+		t.Fatalf("log file was not created")
+	}
+
+	// Delete the log file
+	err := deleteCgenLog(cgenPath)
+	if err != nil {
+		t.Fatalf("deleteCgenLog() returned unexpected error: %v", err)
+	}
+
+	// Verify the log file is gone
+	if utils.FileExists(logPath) {
+		t.Errorf("expected log file to be deleted, but it still exists at %s", logPath)
+	}
+
+	// Test deleting a non-existent log file (should not error)
+	err = deleteCgenLog(cgenPath)
+	if err != nil {
+		t.Fatalf("deleteCgenLog() should not error for non-existent file: %v", err)
+	}
+}
+
+func Test_deleteAllCgenLogs(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create multiple cgen.log files
+	cgenPath1 := filepath.Join(tmpDir, "cgen1.yml")
+	cgenPath2 := filepath.Join(tmpDir, "cgen2.yml")
+
+	logCgenError(cgenPath1, errors.New("error 1"))
+	logCgenError(cgenPath2, errors.New("error 2"))
+
+	logPath1 := strings.TrimSuffix(cgenPath1, ".yml") + ".log"
+	logPath2 := strings.TrimSuffix(cgenPath2, ".yml") + ".log"
+
+	if !utils.FileExists(logPath1) || !utils.FileExists(logPath2) {
+		t.Fatalf("log files were not created")
+	}
+
+	// Delete all logs
+	bridgeParams := []BridgeParamType{
+		{CgenName: cgenPath1},
+		{CgenName: cgenPath2},
+	}
+	deleteAllCgenLogs(bridgeParams)
+
+	// Verify both log files are gone
+	if utils.FileExists(logPath1) {
+		t.Errorf("expected log file 1 to be deleted")
+	}
+	if utils.FileExists(logPath2) {
+		t.Errorf("expected log file 2 to be deleted")
+	}
+}

--- a/internal/stm32CubeMX/stm32CubeMX_test.go
+++ b/internal/stm32CubeMX/stm32CubeMX_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,7 +12,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/open-cmsis-pack/generator-bridge/internal/cbuild"
 )
 
@@ -161,6 +163,289 @@ func Test_WriteProjectFile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_isRelevantCubeMxEvent(t *testing.T) {
+	t.Parallel()
+
+	base := filepath.Clean(filepath.Join("tmp", "out", "STM32CubeMX"))
+	ioc := filepath.Join(base, "STM32CubeMX.ioc")
+	mx := filepath.Join(base, ".mxproject")
+	inner := filepath.Join(base, "Inc", "user.h")
+	outside := filepath.Clean(filepath.Join("tmp", "other", "file.txt"))
+
+	tests := []struct {
+		name  string
+		event fsnotify.Event
+		want  bool
+	}{
+		{
+			name:  "ioc_create_event",
+			event: fsnotify.Event{Name: ioc, Op: fsnotify.Create},
+			want:  true,
+		},
+		{
+			name:  "mxproject_write_event",
+			event: fsnotify.Event{Name: mx, Op: fsnotify.Write},
+			want:  true,
+		},
+		{
+			name:  "tree_write_event",
+			event: fsnotify.Event{Name: inner, Op: fsnotify.Write},
+			want:  true,
+		},
+		{
+			name:  "outside_event",
+			event: fsnotify.Event{Name: outside, Op: fsnotify.Write},
+			want:  false,
+		},
+		{
+			name:  "remove_not_relevant",
+			event: fsnotify.Event{Name: ioc, Op: fsnotify.Remove},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isRelevantCubeMxEvent(tt.event, base, ioc, mx, []string{})
+			if got != tt.want {
+				t.Errorf("isRelevantCubeMxEvent() = %v, want %v for event %+v", got, tt.want, tt.event)
+			}
+		})
+	}
+
+	// Test cgen.yml deletion detection
+	cgen1 := filepath.Join("tmp", "out", "cgen1.yml")
+	cgen2 := filepath.Join("tmp", "out", "cgen2.yml")
+	cgenPaths := []string{cgen1, cgen2}
+
+	cgenDeletionTests := []struct {
+		name  string
+		event fsnotify.Event
+		want  bool
+	}{
+		{
+			name:  "cgen_deletion_detected",
+			event: fsnotify.Event{Name: cgen1, Op: fsnotify.Remove},
+			want:  true,
+		},
+		{
+			name:  "cgen_deletion_detected_second_file",
+			event: fsnotify.Event{Name: cgen2, Op: fsnotify.Remove},
+			want:  true,
+		},
+		{
+			name:  "cgen_rename_detected",
+			event: fsnotify.Event{Name: cgen1, Op: fsnotify.Rename},
+			want:  true,
+		},
+		{
+			name:  "cgen_rename_detected_second_file",
+			event: fsnotify.Event{Name: cgen2, Op: fsnotify.Rename},
+			want:  true,
+		},
+		{
+			name:  "non_cgen_removal_ignored",
+			event: fsnotify.Event{Name: filepath.Join("tmp", "out", "other.txt"), Op: fsnotify.Remove},
+			want:  false,
+		},
+		{
+			name:  "non_cgen_rename_ignored",
+			event: fsnotify.Event{Name: filepath.Join("tmp", "out", "other.txt"), Op: fsnotify.Rename},
+			want:  false,
+		},
+	}
+
+	for _, tt := range cgenDeletionTests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isRelevantCubeMxEvent(tt.event, base, ioc, mx, cgenPaths)
+			if got != tt.want {
+				t.Errorf("isRelevantCubeMxEvent() = %v, want %v for event %+v", got, tt.want, tt.event)
+			}
+		})
+	}
+}
+
+func Test_cgenPathsFromBridgeParams(t *testing.T) {
+	t.Parallel()
+
+	bridgeParams := []BridgeParamType{
+		{CgenName: filepath.Join("tmp", "one.cgen.yml")},
+		{CgenName: filepath.Join("tmp", "two.cgen.yml")},
+	}
+
+	got := cgenPathsFromBridgeParams(bridgeParams)
+	if len(got) != len(bridgeParams) {
+		t.Fatalf("cgenPathsFromBridgeParams() len = %d, want %d", len(got), len(bridgeParams))
+	}
+	for index, want := range []string{bridgeParams[0].CgenName, bridgeParams[1].CgenName} {
+		if got[index] != want {
+			t.Fatalf("cgenPathsFromBridgeParams()[%d] = %q, want %q", index, got[index], want)
+		}
+	}
+}
+
+func Test_handleCubeMxWatchEvent(t *testing.T) {
+	t.Parallel()
+
+	base := filepath.Clean(filepath.Join("tmp", "out", "STM32CubeMX"))
+	ioc := filepath.Join(base, "STM32CubeMX.ioc")
+	mx := filepath.Join(base, ".mxproject")
+	cgen := filepath.Join("tmp", "out", "demo.cgen.yml")
+
+	tests := []struct {
+		name          string
+		event         fsnotify.Event
+		addWatchErr   error
+		wantRelevant  bool
+		wantAddCalls  int
+		wantAddedPath string
+	}{
+		{
+			name:          "cube_dir_create_adds_watch_and_triggers",
+			event:         fsnotify.Event{Name: base, Op: fsnotify.Create},
+			wantRelevant:  true,
+			wantAddCalls:  1,
+			wantAddedPath: base,
+		},
+		{
+			name:          "cube_dir_create_watch_error_still_triggers",
+			event:         fsnotify.Event{Name: base, Op: fsnotify.Create},
+			addWatchErr:   os.ErrPermission,
+			wantRelevant:  true,
+			wantAddCalls:  1,
+			wantAddedPath: base,
+		},
+		{
+			name:         "cgen_rename_triggers_without_add",
+			event:        fsnotify.Event{Name: cgen, Op: fsnotify.Rename},
+			wantRelevant: true,
+		},
+		{
+			name:         "outside_write_ignored",
+			event:        fsnotify.Event{Name: filepath.Join("tmp", "other", "ignored.txt"), Op: fsnotify.Write},
+			wantRelevant: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			addCalls := 0
+			addedPath := ""
+			got := handleCubeMxWatchEvent(tt.event, base, ioc, mx, []string{cgen}, func(path string) error {
+				addCalls++
+				addedPath = path
+				return tt.addWatchErr
+			})
+
+			if got != tt.wantRelevant {
+				t.Fatalf("handleCubeMxWatchEvent() = %v, want %v", got, tt.wantRelevant)
+			}
+			if addCalls != tt.wantAddCalls {
+				t.Fatalf("handleCubeMxWatchEvent() add calls = %d, want %d", addCalls, tt.wantAddCalls)
+			}
+			if tt.wantAddedPath != "" && addedPath != tt.wantAddedPath {
+				t.Fatalf("handleCubeMxWatchEvent() added path = %q, want %q", addedPath, tt.wantAddedPath)
+			}
+		})
+	}
+}
+
+func Test_resetDebounceTimer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resets_active_timer", func(t *testing.T) {
+		t.Parallel()
+
+		timer := time.NewTimer(time.Hour)
+		defer timer.Stop()
+
+		resetDebounceTimer(timer, 20*time.Millisecond)
+
+		select {
+		case <-timer.C:
+		case <-time.After(250 * time.Millisecond):
+			t.Fatal("resetDebounceTimer() did not trigger reset timer")
+		}
+	})
+
+	t.Run("drains_stale_tick_before_reset", func(t *testing.T) {
+		t.Parallel()
+
+		timer := time.NewTimer(10 * time.Millisecond)
+		defer timer.Stop()
+
+		time.Sleep(40 * time.Millisecond)
+		resetDebounceTimer(timer, 30*time.Millisecond)
+
+		select {
+		case <-timer.C:
+			t.Fatal("resetDebounceTimer() observed a stale tick immediately after reset")
+		case <-time.After(10 * time.Millisecond):
+		}
+
+		select {
+		case <-timer.C:
+		case <-time.After(250 * time.Millisecond):
+			t.Fatal("resetDebounceTimer() did not trigger after draining stale tick")
+		}
+	})
+}
+
+func Test_ProcessEarlyFailures(t *testing.T) {
+	t.Run("missing_cmsis_compiler_root_dir", func(t *testing.T) {
+		t.Setenv("CMSIS_COMPILER_ROOT", filepath.Join(t.TempDir(), "missing"))
+
+		err := Process(filepath.Join(t.TempDir(), "unused.cbuild-gen-idx.yml"), "out", "", false, -1)
+		if err == nil {
+			t.Fatal("Process() error = nil, want missing CMSIS_COMPILER_ROOT directory error")
+		}
+		if !strings.Contains(err.Error(), "CMSIS_COMPILER_ROOT directory does not exist") {
+			t.Fatalf("Process() error = %q, want missing CMSIS_COMPILER_ROOT directory", err)
+		}
+	})
+
+	t.Run("missing_global_generator_file", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("CMSIS_COMPILER_ROOT", root)
+
+		err := Process(filepath.Join(root, "unused.cbuild-gen-idx.yml"), "out", "", false, -1)
+		if err == nil {
+			t.Fatal("Process() error = nil, want missing global.generator.yml error")
+		}
+		if !strings.Contains(err.Error(), "config file 'global.generator.yml' not found") {
+			t.Fatalf("Process() error = %q, want missing global.generator.yml", err)
+		}
+	})
+
+	t.Run("missing_cbuild_idx_after_generator_load", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv("CMSIS_COMPILER_ROOT", root)
+
+		generatorPath := filepath.Join(root, "global.generator.yml")
+		generatorYML := "generator:\n  - id: CubeMX\n    description: test\n    download-url: https://example.invalid\n    run: ../bin/cbridge\n    path: $SolutionDir()$/STM32CubeMX/$TargetType$\n"
+		if err := os.WriteFile(generatorPath, []byte(generatorYML), 0600); err != nil {
+			t.Fatalf("os.WriteFile() error = %v", err)
+		}
+
+		missingIdx := filepath.Join(root, "missing.cbuild-gen-idx.yml")
+		err := Process(missingIdx, "out", "", false, -1)
+		if err == nil {
+			t.Fatal("Process() error = nil, want missing cbuild idx error")
+		}
+		errMsg := strings.ToLower(err.Error())
+		if !strings.Contains(errMsg, "file not found") && !strings.Contains(errMsg, "cannot find the file specified") && !strings.Contains(errMsg, "no such file or directory") {
+			t.Fatalf("Process() error = %q, want missing cbuild idx error", err)
+		}
+	})
 }
 
 func Test_GetBridgeInfo(t *testing.T) {


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/generator-bridge/issues/325
- https://github.com/Open-CMSIS-Pack/generator-bridge/issues/334

## Changes
<!-- List the changes this PR introduces -->
This PR improves reliability and observability of STM32 CubeMX integration by adding per-cgen log files, broadening regeneration triggers, and making selected MX_Device failures non-blocking.
- Implement watcher and debounce behavior replacing polling cycle, using less CPU and I/O overhead in a simpler and safer control flow.
- Regeneration now also triggers on cgen file remove/rename events.
- Added per-cgen log handling: it saves daemon errors and warnings in a `*.cgen.log` file alongside `*.cgen.yml`
- Made selected writeMXdeviceH failures non-blocking: if peripheral source file open fails in paired generation mode, write warning to cgen log. Partial MX_Device output is allowed for this case.
- Added and updated tests for logging helpers and event/debounce helpers.

## Behavior Notes
- cgen logs persist during daemon runtime and are cleared at daemon startup.
- writeMXdeviceH peripheral-open failures are warning-level and non-blocking.
- Blocking errors in processCubeMxUpdate are logged to cgen logs before returning.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
