### PR TITLE
Handle file locations for Advanced Application Structure

### DIFF
--- a/internal/stm32CubeMX/mxDevice.go
+++ b/internal/stm32CubeMX/mxDevice.go
@@ -51,6 +51,10 @@ func ReadContexts(iocFile string, params []BridgeParamType) error {
 		return errors.New("main location missing")
 	}
 
+	for i := range params {
+		params[i].MainLocation = mainFolder
+	}
+
 	for _, context := range contexts {
 		for _, parm := range params {
 			if parm.CubeContext == context {
@@ -58,7 +62,7 @@ func ReadContexts(iocFile string, params []BridgeParamType) error {
 
 				var mspName string
 				err = filepath.Walk(srcFolderPath, func(path string, f fs.FileInfo, err error) error {
-					if f.Mode().IsRegular() && strings.HasSuffix(f.Name(), "_hal_msp.c") {
+					if f != nil && f.Mode().IsRegular() && strings.HasSuffix(f.Name(), "_hal_msp.c") {
 						mspName = filepath.Base(path)
 						return nil
 					}

--- a/internal/stm32CubeMX/mxDevice_test.go
+++ b/internal/stm32CubeMX/mxDevice_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -86,7 +86,7 @@ func Test_ReadContexts(t *testing.T) {
 		params  BridgeParamType
 		wantErr bool
 	}{
-		{"STM32H7_SC", "../../testdata/testExamples/STM32H7_SC/STM32CubeMX/device/STM32CubeMX/STM32CubeMX.ioc", BridgeParamType{"device", "", "STM32H743AGIx", "", "test", "single-core", "", "", "AC6", "", "test", "", ""}, false},
+		{"STM32H7_SC", "../../testdata/testExamples/STM32H7_SC/STM32CubeMX/device/STM32CubeMX/STM32CubeMX.ioc", BridgeParamType{BoardName: "device", Device: "STM32H743AGIx", ProjectName: "test", ProjectType: "single-core", Compiler: "AC6", CgenName: "test"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -94,7 +94,38 @@ func Test_ReadContexts(t *testing.T) {
 			if err := ReadContexts(tt.iocFile, argsSlice); (err != nil) != tt.wantErr {
 				t.Errorf("ReadContexts() %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			}
+			if !tt.wantErr && len(argsSlice) > 0 && argsSlice[0].MainLocation != "Src" {
+				t.Errorf("ReadContexts() %s MainLocation = %v, want Src", tt.name, argsSlice[0].MainLocation)
+			}
 		})
+	}
+}
+
+func Test_ReadContexts_NoPanicOnWalkFileInfoNil(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	iocFile := filepath.Join(tmpDir, "test.ioc")
+
+	// MainLocation points to a missing folder so filepath.Walk receives nil FileInfo.
+	if err := os.WriteFile(iocFile, []byte("ProjectManager.MainLocation=missing-folder\n"), 0o600); err != nil {
+		t.Fatalf("failed to write ioc file: %v", err)
+	}
+
+	params := []BridgeParamType{{
+		CubeContext:       "",
+		CubeContextFolder: "",
+	}}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ReadContexts panicked: %v", r)
+		}
+	}()
+
+	err := ReadContexts(iocFile, params)
+	if err == nil {
+		t.Fatalf("ReadContexts() expected error for missing source folder")
 	}
 }
 

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -856,6 +856,7 @@ func WriteCgenYmlSub(outPath string, mxproject MxprojectType, bridgeParam Bridge
 		logCgenError(bridgeParam.CgenName, err)
 		return err
 	}
+	logCgenInfoIfLogExists(bridgeParam.CgenName, "cgen.yml generated successfully")
 
 	return nil
 }

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -41,6 +41,7 @@ type BridgeParamType struct {
 	CgenName          string
 	CubeContext       string
 	CubeContextFolder string
+	MainLocation      string
 }
 
 var watcher *fsnotify.Watcher
@@ -193,6 +194,12 @@ func Process(cbuildGenIdxYmlPath, outPath, cubeMxPath string, runCubeMx bool, pi
 	var generatorFile string
 	// #nosec G703 -- cRoot is validated via filepath.Clean, filepath.Abs, and DirExists checks
 	err = filepath.Walk(cRoot, func(path string, f fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if f == nil {
+			return errors.New("unexpected nil FileInfo for path: " + path)
+		}
 		if f.Mode().IsRegular() && strings.Contains(path, "global.generator.yml") {
 			generatorFile = path
 			return nil
@@ -929,7 +936,11 @@ func GetStartupFile(outPath string, bridgeParams BridgeParamType) (string, error
 	}
 
 	if bridgeParams.Compiler == "GCC" || bridgeParams.Compiler == "CLANG" {
-		startupFolder = filepath.Join(startupFolder, bridgeParams.CubeContextFolder, "Application", "Startup")
+		startupSubFolder := "Application"
+		if bridgeParams.MainLocation != "Src" {
+			startupSubFolder = filepath.Join(startupSubFolder, "User")
+		}
+		startupFolder = filepath.Join(startupFolder, bridgeParams.CubeContextFolder, startupSubFolder, "Startup")
 	}
 
 	if !utils.DirExists(startupFolder) {
@@ -948,6 +959,12 @@ func GetStartupFile(outPath string, bridgeParams BridgeParamType) (string, error
 	}
 
 	err = filepath.Walk(startupFolder, func(path string, f fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if f == nil {
+			return errors.New("unexpected nil FileInfo for path: " + path)
+		}
 		if f.Mode().IsRegular() &&
 			strings.HasPrefix(f.Name(), "startup_") &&
 			fExt[filepath.Ext(f.Name())] {
@@ -1012,7 +1029,7 @@ func GetSystemFile(outPath string, bridgeParams BridgeParamType) (string, error)
 			systemFolder = filepath.Join(systemFolder, bridgeParams.CubeContextFolder)
 		}
 
-		systemFolder = filepath.Join(systemFolder, "Src")
+		systemFolder = filepath.Join(systemFolder, bridgeParams.MainLocation)
 	}
 
 	if !utils.DirExists(systemFolder) {
@@ -1023,6 +1040,12 @@ func GetSystemFile(outPath string, bridgeParams BridgeParamType) (string, error)
 
 	var systemFile string
 	err = filepath.Walk(systemFolder, func(path string, f fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if f == nil {
+			return errors.New("unexpected nil FileInfo for path: " + path)
+		}
 		if f.Mode().IsRegular() &&
 			strings.HasPrefix(f.Name(), "system_stm32") &&
 			strings.HasSuffix(f.Name(), ".c") {

--- a/internal/stm32CubeMX/stm32CubeMX_cgenlog.go
+++ b/internal/stm32CubeMX/stm32CubeMX_cgenlog.go
@@ -17,9 +17,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func getCgenLogPath(cgenPath string) string {
+	return strings.TrimSuffix(cgenPath, ".yml") + ".log"
+}
+
 // deleteCgenLog deletes the *.cgen.log file for a given cgen path.
 func deleteCgenLog(cgenPath string) error {
-	logPath := strings.TrimSuffix(cgenPath, ".yml") + ".log"
+	logPath := getCgenLogPath(cgenPath)
 	if utils.FileExists(logPath) {
 		return os.Remove(logPath)
 	}
@@ -28,7 +32,7 @@ func deleteCgenLog(cgenPath string) error {
 
 // logCgenError appends an error message with timestamp and function name to the *.cgen.log file.
 func logCgenError(cgenPath string, err error) {
-	logPath := strings.TrimSuffix(cgenPath, ".yml") + ".log"
+	logPath := getCgenLogPath(cgenPath)
 
 	// Get caller's function name.
 	pc, _, _, _ := runtime.Caller(1)
@@ -53,6 +57,30 @@ func logCgenError(cgenPath string, err error) {
 
 	_, writeErr := file.WriteString(message)
 	if writeErr != nil {
+		log.Warnf("failed to write cgen log '%s': %v", logPath, writeErr)
+	}
+}
+
+// logCgenInfoIfLogExists appends an info message only when the cgen log already
+// exists. This is used in daemon mode to acknowledge recovery after prior
+// errors/warnings in the same session.
+func logCgenInfoIfLogExists(cgenPath, message string) {
+	logPath := getCgenLogPath(cgenPath)
+	if !utils.FileExists(logPath) {
+		return
+	}
+
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	entry := fmt.Sprintf("[%s] info: %s\n", timestamp, message)
+
+	file, openErr := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY, 0600)
+	if openErr != nil {
+		log.Warnf("failed to open cgen log '%s': %v", logPath, openErr)
+		return
+	}
+	defer file.Close()
+
+	if _, writeErr := file.WriteString(entry); writeErr != nil {
 		log.Warnf("failed to write cgen log '%s': %v", logPath, writeErr)
 	}
 }

--- a/internal/stm32CubeMX/stm32CubeMX_cgenlog_test.go
+++ b/internal/stm32CubeMX/stm32CubeMX_cgenlog_test.go
@@ -128,3 +128,34 @@ func Test_deleteAllCgenLogs(t *testing.T) {
 		t.Errorf("expected log file 2 to be deleted")
 	}
 }
+
+func Test_logCgenInfoIfLogExists(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cgenPath := filepath.Join(tmpDir, "test.cgen.yml")
+	logPath := strings.TrimSuffix(cgenPath, ".yml") + ".log"
+
+	// No existing log: no file should be created.
+	logCgenInfoIfLogExists(cgenPath, "cgen.yml generated successfully")
+	if utils.FileExists(logPath) {
+		t.Fatalf("expected no log file to be created when none exists")
+	}
+
+	// Existing log: info should be appended.
+	logCgenError(cgenPath, errors.New("prior warning"))
+	logCgenInfoIfLogExists(cgenPath, "cgen.yml generated successfully")
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "prior warning") {
+		t.Errorf("expected prior error/warning in log, got: %s", content)
+	}
+	if !strings.Contains(content, "info: cgen.yml generated successfully") {
+		t.Errorf("expected success info in log, got: %s", content)
+	}
+}

--- a/internal/stm32CubeMX/stm32CubeMX_test.go
+++ b/internal/stm32CubeMX/stm32CubeMX_test.go
@@ -886,6 +886,7 @@ func Test_WriteCgenYmlSub(t *testing.T) {
 		CgenName:          filepath.Join(tmpDir, "Cgen.yml"),
 		CubeContext:       "",
 		CubeContextFolder: "",
+		MainLocation:      "Src",
 	}
 
 	if err := WriteCgenYmlSub(base, mx, bp); err != nil {
@@ -941,8 +942,8 @@ func Test_WriteCgenYml(t *testing.T) {
 	all := MxprojectAllType{Mxproject: []MxprojectType{mx1, mx2}}
 
 	params := []BridgeParamType{
-		{CubeContext: "Ctx1", Compiler: "GCC", CgenName: filepath.Join(tmpDir, "cgen1.yml")},
-		{CubeContext: "Ctx2", Compiler: "GCC", CgenName: filepath.Join(tmpDir, "cgen2.yml")},
+		{CubeContext: "Ctx1", Compiler: "GCC", CgenName: filepath.Join(tmpDir, "cgen1.yml"), MainLocation: "Src"},
+		{CubeContext: "Ctx2", Compiler: "GCC", CgenName: filepath.Join(tmpDir, "cgen2.yml"), MainLocation: "Src"},
 	}
 
 	if err := WriteCgenYml(base, all, params); err != nil {
@@ -1090,12 +1091,14 @@ func Test_GetStartupFile(t *testing.T) {
 	infoScGCC.ForProjectPart = ""
 	infoScGCC.CubeContext = ""
 	infoScGCC.CubeContextFolder = ""
+	infoScGCC.MainLocation = "Src"
 	var infoScCLANG BridgeParamType
 	infoScCLANG.Compiler = "CLANG"
 	infoScCLANG.ProjectType = "single-core"
 	infoScCLANG.ForProjectPart = ""
 	infoScCLANG.CubeContext = ""
 	infoScCLANG.CubeContextFolder = ""
+	infoScCLANG.MainLocation = "Src"
 	var infoScIAR BridgeParamType
 	infoScIAR.Compiler = "IAR"
 	infoScIAR.ProjectType = "single-core"
@@ -1117,12 +1120,14 @@ func Test_GetStartupFile(t *testing.T) {
 	infoDcGCC.ForProjectPart = "CM7"
 	infoDcGCC.CubeContext = "CortexM7"
 	infoDcGCC.CubeContextFolder = "CM7"
+	infoDcGCC.MainLocation = "Src"
 	var infoDcCLANG BridgeParamType
 	infoDcCLANG.Compiler = "CLANG"
 	infoDcCLANG.ProjectType = "multi-core"
 	infoDcCLANG.ForProjectPart = "CM4"
 	infoDcCLANG.CubeContext = "CortexM4"
 	infoDcCLANG.CubeContextFolder = "CM4"
+	infoDcCLANG.MainLocation = "Src"
 	var infoDcIAR BridgeParamType
 	infoDcIAR.Compiler = "IAR"
 	infoDcIAR.ProjectType = "multi-core"
@@ -1144,12 +1149,14 @@ func Test_GetStartupFile(t *testing.T) {
 	infoTzGCC.ForProjectPart = "non-secure"
 	infoTzGCC.CubeContext = "CortexM33NS"
 	infoTzGCC.CubeContextFolder = "NonSecure"
+	infoTzGCC.MainLocation = "Src"
 	var infoTzCLANG BridgeParamType
 	infoTzCLANG.Compiler = "CLANG"
 	infoTzCLANG.ProjectType = "trustzone"
 	infoTzCLANG.ForProjectPart = "secure"
 	infoTzCLANG.CubeContext = "CortexM33S"
 	infoTzCLANG.CubeContextFolder = "Secure"
+	infoTzCLANG.MainLocation = "Src"
 	var infoTzIAR BridgeParamType
 	infoTzIAR.Compiler = "IAR"
 	infoTzIAR.ProjectType = "trustzone"
@@ -1171,12 +1178,14 @@ func Test_GetStartupFile(t *testing.T) {
 	infoDcM0PGCC.ForProjectPart = "CM4"
 	infoDcM0PGCC.CubeContext = "CortexM4"
 	infoDcM0PGCC.CubeContextFolder = "CM4"
+	infoDcM0PGCC.MainLocation = "Src"
 	var infoDcM0PCLANG BridgeParamType
 	infoDcM0PCLANG.Compiler = "CLANG"
 	infoDcM0PCLANG.ProjectType = "multi-core"
 	infoDcM0PCLANG.ForProjectPart = "CM0P"
 	infoDcM0PCLANG.CubeContext = "CortexM0Plus"
 	infoDcM0PCLANG.CubeContextFolder = "CM0PLUS"
+	infoDcM0PCLANG.MainLocation = "Src"
 	var infoDcM0PIAR BridgeParamType
 	infoDcM0PIAR.Compiler = "IAR"
 	infoDcM0PIAR.ProjectType = "multi-core"
@@ -1239,6 +1248,38 @@ func Test_GetStartupFile(t *testing.T) {
 	}
 }
 
+func Test_GetStartupFile_ApplicationUserStartupSelectedWhenMainLocationNotSrc(t *testing.T) {
+	t.Parallel()
+
+	outPath := t.TempDir()
+	startupFolder := filepath.Join(outPath, "STM32CubeMX", "STM32CubeIDE", "CM7", "Application", "User", "Startup")
+	if err := os.MkdirAll(startupFolder, 0o755); err != nil {
+		t.Fatalf("failed to create startup folder: %v", err)
+	}
+
+	startupFile := filepath.Join(startupFolder, "startup_stm32f4xx.s")
+	if err := os.WriteFile(startupFile, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("failed to create startup file: %v", err)
+	}
+
+	info := BridgeParamType{
+		Compiler:          "GCC",
+		ProjectType:       "multi-core",
+		ForProjectPart:    "CM7",
+		CubeContext:       "CortexM7",
+		CubeContextFolder: "CM7",
+		MainLocation:      "Flash",
+	}
+
+	got, err := GetStartupFile(outPath, info)
+	if err != nil {
+		t.Fatalf("GetStartupFile() error = %v", err)
+	}
+	if got != startupFile {
+		t.Errorf("GetStartupFile() = %v, want %v", got, startupFile)
+	}
+}
+
 func Test_GetSystemFile(t *testing.T) {
 	t.Parallel()
 
@@ -1256,12 +1297,14 @@ func Test_GetSystemFile(t *testing.T) {
 	infoScGCC.ForProjectPart = ""
 	infoScGCC.CubeContext = ""
 	infoScGCC.CubeContextFolder = ""
+	infoScGCC.MainLocation = "Src"
 	var infoScCLANG BridgeParamType
 	infoScCLANG.Compiler = "CLANG"
 	infoScCLANG.ProjectType = "single-core"
 	infoScCLANG.ForProjectPart = ""
 	infoScCLANG.CubeContext = ""
 	infoScCLANG.CubeContextFolder = ""
+	infoScCLANG.MainLocation = "Src"
 	var infoScIAR BridgeParamType
 	infoScIAR.Compiler = "IAR"
 	infoScIAR.ProjectType = "single-core"
@@ -1310,12 +1353,14 @@ func Test_GetSystemFile(t *testing.T) {
 	infoTzGCC.ForProjectPart = "non-secure"
 	infoTzGCC.CubeContext = "CortexM33NS"
 	infoTzGCC.CubeContextFolder = "NonSecure"
+	infoTzGCC.MainLocation = "Src"
 	var infoTzCLANG BridgeParamType
 	infoTzCLANG.Compiler = "CLANG"
 	infoTzCLANG.ProjectType = "trustzone"
 	infoTzCLANG.ForProjectPart = "secure"
 	infoTzCLANG.CubeContext = "CortexM33S"
 	infoTzCLANG.CubeContextFolder = "Secure"
+	infoTzCLANG.MainLocation = "Src"
 	var infoTzIAR BridgeParamType
 	infoTzIAR.Compiler = "IAR"
 	infoTzIAR.ProjectType = "trustzone"
@@ -1402,6 +1447,35 @@ func Test_GetSystemFile(t *testing.T) {
 				t.Errorf("GetSystemFile() %s = %v, want %v", tt.name, got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_GetSystemFile_UsesMainLocationFolder(t *testing.T) {
+	t.Parallel()
+
+	outPath := t.TempDir()
+	systemFolder := filepath.Join(outPath, "STM32CubeMX", "Application", "User")
+	if err := os.MkdirAll(systemFolder, 0o755); err != nil {
+		t.Fatalf("failed to create system folder: %v", err)
+	}
+
+	systemFile := filepath.Join(systemFolder, "system_stm32f4xx.c")
+	if err := os.WriteFile(systemFile, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("failed to create system file: %v", err)
+	}
+
+	info := BridgeParamType{
+		Compiler:     "GCC",
+		ProjectType:  "single-core",
+		MainLocation: filepath.Join("Application", "User"),
+	}
+
+	got, err := GetSystemFile(outPath, info)
+	if err != nil {
+		t.Fatalf("GetSystemFile() error = %v", err)
+	}
+	if got != systemFile {
+		t.Errorf("GetSystemFile() = %v, want %v", got, systemFile)
 	}
 }
 


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/generator-bridge/issues/324

## Changes
<!-- List the changes this PR introduces -->
- MainLocation is now propagated from IOC parsing in ReadContexts.
- Startup path resolution for GCC/CLANG now follows:
  - Basic → Application/Startup
  - Advanced → Application/User/Startup
- System file folder resolution now uses MainLocation
- ReadContexts walk callback safety (no panic with nil FileInfo)
- Added/updated tests

## Important note for users
Do not change ProjectManager.MainLocation in the IOC file after CubeMX code has already been generated for a project.
For existing projects, changing MainLocation can cause CubeMX to regenerate sources into a different and unexpected folder layout, which may break downstream file discovery and build integration.
This behavior is consistent with CubeMX UI: for existing projects, the Application Structure setting is grayed out, indicating the structure is intended to remain fixed once code has been generated.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
