### PR TITLE
Avoid rewriting unchanged generated `*.cgen.yml`

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -31,15 +31,18 @@ func ReadYml(path string, out interface{}) error {
 	return nil
 }
 
-// WriteYml writes YAML to path when its content has changed.
+// WriteYml serializes out as YAML and writes it to path only when the on-disk content differs.
+// It returns true if a write occurred, or false if the existing file was already up-to-date.
 // Callers must not concurrently modify the destination file.
 func WriteYml(path string, out interface{}) (bool, error) {
 	var data bytes.Buffer
 	yamlEncoder := yaml.NewEncoder(&data)
 	yamlEncoder.SetIndent(2)
-	err := yamlEncoder.Encode(&out)
-	if err != nil {
-		return false, err
+	if err := yamlEncoder.Encode(&out); err != nil {
+		return false, fmt.Errorf("encode YAML %q: %w", path, err)
+	}
+	if err := yamlEncoder.Close(); err != nil {
+		return false, fmt.Errorf("close YAML encoder for %q: %w", path, err)
 	}
 
 	// If the existing file cannot be read, attempt the write because content

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -8,6 +8,7 @@ package common
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -30,19 +31,27 @@ func ReadYml(path string, out interface{}) error {
 	return nil
 }
 
-func WriteYml(path string, out interface{}) error {
+// WriteYml writes YAML to path when its content has changed.
+// Callers must not concurrently modify the destination file.
+func WriteYml(path string, out interface{}) (bool, error) {
 	var data bytes.Buffer
 	yamlEncoder := yaml.NewEncoder(&data)
 	yamlEncoder.SetIndent(2)
 	err := yamlEncoder.Encode(&out)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	err = os.WriteFile(path, data.Bytes(), 0600)
-	if err != nil {
-		log.Fatal(err)
+	// If the existing file cannot be read, attempt the write because content
+	// comparison is an optimization and writing the generated YAML is primary.
+	existingData, err := os.ReadFile(path)
+	if err == nil && bytes.Equal(existingData, data.Bytes()) {
+		return false, nil
 	}
 
-	return nil
+	if err := os.WriteFile(path, data.Bytes(), 0600); err != nil {
+		return false, fmt.Errorf("write YAML %q: %w", path, err)
+	}
+
+	return true, nil
 }

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -7,8 +7,11 @@
 package common
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestReadYml(t *testing.T) {
@@ -45,5 +48,60 @@ func TestReadYml(t *testing.T) {
 				t.Errorf("ReadYml() %s got = %v, want %v", tt.name, tt.args.out, tt.want)
 			}
 		})
+	}
+}
+
+func TestWriteYmlDoesNotTouchUnchangedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.cgen.yml")
+	content := struct {
+		Value string `yaml:"value"`
+	}{Value: "unchanged"}
+
+	changed, err := WriteYml(path, &content)
+	if err != nil {
+		t.Fatalf("initial WriteYml() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("initial WriteYml() changed = false, want true")
+	}
+
+	modTime := time.Date(2020, time.January, 2, 3, 4, 5, 0, time.UTC)
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("os.Chtimes() error = %v", err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat() before second write error = %v", err)
+	}
+
+	changed, err = WriteYml(path, &content)
+	if err != nil {
+		t.Fatalf("second WriteYml() error = %v", err)
+	}
+	if changed {
+		t.Fatal("second WriteYml() changed = true, want false")
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat() after second write error = %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("modification time changed from %v to %v", before.ModTime(), after.ModTime())
+	}
+}
+
+func TestWriteYmlReturnsWriteError(t *testing.T) {
+	path := t.TempDir()
+	content := struct {
+		Value string `yaml:"value"`
+	}{Value: "test"}
+
+	changed, err := WriteYml(path, &content)
+	if err == nil {
+		t.Fatal("WriteYml() error = nil, want write error")
+	}
+	if changed {
+		t.Fatal("WriteYml() changed = true after failed write, want false")
 	}
 }

--- a/internal/stm32CubeMX/stm32CubeMX.go
+++ b/internal/stm32CubeMX/stm32CubeMX.go
@@ -851,12 +851,16 @@ func WriteCgenYmlSub(outPath string, mxproject MxprojectType, bridgeParam Bridge
 		cgen.GeneratorImport.Groups = append(cgen.GeneratorImport.Groups, groupTz)
 	}
 
-	err = common.WriteYml(bridgeParam.CgenName, &cgen)
+	changed, err := common.WriteYml(bridgeParam.CgenName, &cgen)
 	if err != nil {
 		logCgenError(bridgeParam.CgenName, err)
 		return err
 	}
-	logCgenInfoIfLogExists(bridgeParam.CgenName, "cgen.yml generated successfully")
+	message := "cgen.yml is already up-to-date"
+	if changed {
+		message = "cgen.yml generated successfully"
+	}
+	logCgenInfoIfLogExists(bridgeParam.CgenName, message)
 
 	return nil
 }

--- a/internal/stm32CubeMX/stm32CubeMX_test.go
+++ b/internal/stm32CubeMX/stm32CubeMX_test.go
@@ -7,6 +7,7 @@
 package stm32cubemx
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -910,6 +911,18 @@ func Test_WriteCgenYmlSub(t *testing.T) {
 	}
 	if strings.Contains(content, "Templates") {
 		t.Errorf("filtered header path Templates should not appear")
+	}
+
+	logCgenError(bp.CgenName, errors.New("prior warning"))
+	if err := WriteCgenYmlSub(base, mx, bp); err != nil {
+		t.Fatalf("second WriteCgenYmlSub error: %v", err)
+	}
+	logData, err := os.ReadFile(getCgenLogPath(bp.CgenName))
+	if err != nil {
+		t.Fatalf("read cgen log: %v", err)
+	}
+	if !strings.Contains(string(logData), "info: cgen.yml is already up-to-date") {
+		t.Errorf("expected up-to-date info in log, got: %s", logData)
 	}
 }
 


### PR DESCRIPTION
## Fixes
- Prevents unchanged `.cgen.yml` files from receiving unnecessary modification-time updates.
- Complementary to https://github.com/Open-CMSIS-Pack/generator-bridge/pull/335

## Changes
- Updated `WriteYml` to compare serialized YAML with existing content and report whether a write occurred.
- Propagated write failures to callers instead of terminating the process.
- Added distinct generation and already-up-to-date log messages.
- Added unit tests for unchanged-file timestamp preservation, write-error handling, and STM32CubeMX up-to-date logging.

## Risks / Limitations
- If an existing file cannot be read, `WriteYml` intentionally attempts to overwrite it because generation takes precedence over comparison.
- Callers must not concurrently modify the destination file.

## Checklist
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).